### PR TITLE
I've implemented a new protocol for defining agent capabilities, inpu…

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -4,58 +4,199 @@ Agents are the core workers in the Autonomous App Suite. They are specialized Py
 
 ## Base Agent (`base_agent.py`)
 
-All agents must inherit from the `BaseAgent` abstract base class. This class defines the common interface for all agents:
+All agents must inherit from the `BaseAgent` abstract base class defined in `agents/base_agent.py`. This class defines the common interface for all agents:
 
 *   `async process_request(self, app_spec: AppSpecification, project_state: ProjectState) -> AgentOutput:`:
-    Typically called for the first agent in a chain, or when an agent needs to primarily work from the overall `AppSpecification`. It should process the request and can delegate to its own `execute_task` or suggest the next agent.
-*   `async execute_task(self, task_details: Any, project_state: ProjectState) -> AgentOutput:`:
-    Called when an agent needs to perform a specific, well-defined task, often based on the output of a previous agent. The `task_details` will vary depending on the agent and task.
-*   `get_capabilities(self) -> dict:`:
-    Returns a dictionary describing the agent's name, purpose, and the tasks it can perform. This can be used by the orchestrator for agent selection.
+    This method is typically called when an agent needs to perform a more general task based on the overall `AppSpecification`, or it might be the entry point for the first agent in a sequence. Its role can be to initialize a process or to delegate to a more specific task via `execute_task`.
+*   `async execute_task(self, task_name: str, task_details: Any, project_state: ProjectState) -> AgentOutput:`:
+    This is the primary method for performing a specific, well-defined task.
+    -   `task_name` (str): Identifies the specific task the agent should perform (e.g., "generate_code_from_plan").
+    -   `task_details` (Any): Contains the input data required for the task. This data should conform to the Pydantic schema defined in the `TaskInputSpec` for the corresponding `task_name` in `get_capabilities()`.
+*   `get_capabilities(self) -> Dict[str, TaskDefinition]:`:
+    Returns a dictionary where keys are task names (strings) and values are `TaskDefinition` objects. This method advertises the agent's capabilities to the orchestrator.
+    *   **`TaskDefinition`**: A Pydantic model that describes a specific task. It includes:
+        *   `task_name` (str): The unique identifier for the task.
+        *   `description` (str): A human-readable description of the task.
+        *   `input_spec` (`TaskInputSpec`): Defines the expected input for the task.
+        *   `output_spec` (`TaskOutputSpec`): Defines the expected output of the task.
+    *   **`TaskInputSpec`**: A Pydantic model describing the input requirements.
+        *   `description` (str): Describes the input data.
+        *   `schema` (Type[BaseModel]): A reference to a Pydantic model that defines the structure of `task_details` expected by `execute_task`.
+    *   **`TaskOutputSpec`**: A Pydantic model describing the output structure.
+        *   `description` (str): Describes the output data.
+        *   `schema` (Type[BaseModel]): A reference to a Pydantic model that defines the structure of the `output_data` field within the `AgentOutput` returned by `execute_task`.
 
-The `AgentOutput` Pydantic model is used as the return type for `process_request` and `execute_task`. It includes status, messages, output data, and hints for the next agent.
+The `AgentOutput` Pydantic model is used as the return type for both `process_request` and `execute_task`. It includes:
+*   `status` (str): "success", "failure", "pending", etc.
+*   `output_data` (Optional[Dict]): A dictionary containing the results of the task. For tasks defined in `get_capabilities`, this dictionary should conform to the `schema` specified in the `TaskOutputSpec`.
+*   `message` (Optional[str]): A human-readable message about the outcome.
+*   `next_agent_hint` (Optional[str]): A suggestion for the next agent to handle the workflow.
+*   `request_clarification` (Optional[str]): If the agent needs more information.
 
 ## Creating a New Agent
 
-1.  **Define the Agent Class:**
-    Create a new Python file in the `agents/` directory (e.g., `my_new_agent.py`).
-    Define your class, inheriting from `BaseAgent`:
+1.  **Define Task-Specific Pydantic Models:**
+    Before creating the agent, define Pydantic models for the inputs and outputs of the tasks your agent will perform. These models will be referenced in `TaskInputSpec` and `TaskOutputSpec`.
+
     ```python
-    from .base_agent import BaseAgent, AgentOutput
-    from suite_core.app_spec import AppSpecification # If needed
-    from suite_core.project_state import ProjectState # If needed
-    from typing import Any
+    # In your_agent_file.py or a shared models file
+    from pydantic import BaseModel
+    from typing import List
+
+    class MyTaskInput(BaseModel):
+        item_id: int
+        description: str
+
+    class MyTaskOutput(BaseModel):
+        processed_item_id: int
+        status_message: str
+        generated_artifacts: List[str]
+    ```
+
+2.  **Define the Agent Class:**
+    Create a new Python file in the `agents/` directory (e.g., `my_new_agent.py`).
+    Define your class, inheriting from `BaseAgent` and the new task specification models from `agents.base_agent`.
+
+    ```python
+    # In agents/my_new_agent.py
+    import logging
+    from typing import Any, Dict, Union # Union for task_details type hint
+    from pydantic import BaseModel # For task I/O models if defined in the same file
+
+    from .base_agent import BaseAgent, AgentOutput, TaskDefinition, TaskInputSpec, TaskOutputSpec
+    # If MyTaskInput/MyTaskOutput are in a different file, import them:
+    # from .my_agent_models import MyTaskInput, MyTaskOutput 
+    from suite_core.app_spec import AppSpecification
+    from suite_core.project_state import ProjectState
+
+    logger = logging.getLogger(__name__)
+
+    # Example Pydantic models for task I/O (can be in a separate file)
+    class MyTaskInput(BaseModel):
+        item_id: int
+        instruction: str
+
+    class MyTaskOutput(BaseModel):
+        item_id: int
+        result: str
+        is_complete: bool
 
     class MyNewAgent(BaseAgent):
         async def process_request(self, app_spec: AppSpecification, project_state: ProjectState) -> AgentOutput:
-            # Logic for processing the initial request
-            # ...
-            return AgentOutput(status="success", message="Processed by MyNewAgent")
+            logger.info("MyNewAgent: process_request called, can delegate to a specific task.")
+            # Example: Delegate to 'my_specific_task_1' if certain conditions are met
+            # task_input = MyTaskInput(item_id=123, instruction="Process this item based on app_spec")
+            # return await self.execute_task("my_specific_task_1", task_input, project_state)
+            return AgentOutput(status="pending", message="MyNewAgent ready for specific task.")
 
-        async def execute_task(self, task_details: Any, project_state: ProjectState) -> AgentOutput:
-            # Logic for executing a specific task
-            # ...
-            return AgentOutput(status="success", message=f"Task {task_details} executed by MyNewAgent")
+        async def execute_task(self, task_name: str, task_details: Union[MyTaskInput, Dict[str, Any]], project_state: ProjectState) -> AgentOutput:
+            logger.info(f"MyNewAgent: Executing task '{task_name}'")
+            
+            parsed_task_details: MyTaskInput # Or a Union if multiple tasks with different inputs
+            
+            if task_name == "my_specific_task_1":
+                try:
+                    if isinstance(task_details, dict):
+                        parsed_task_details = MyTaskInput(**task_details)
+                    elif isinstance(task_details, MyTaskInput):
+                        parsed_task_details = task_details
+                    else:
+                        return AgentOutput(status="failure", message="Invalid task_details type for my_specific_task_1")
+                except Exception as e:
+                    logger.error(f"Error parsing task_details for my_specific_task_1: {e}")
+                    return AgentOutput(status="failure", message=f"Invalid input for my_specific_task_1: {e}")
 
-        def get_capabilities(self) -> dict:
+                # --- Your agent's logic for 'my_specific_task_1' here ---
+                logger.info(f"Processing item: {parsed_task_details.item_id} with instruction: {parsed_task_details.instruction}")
+                # ... actual processing ...
+                
+                output_content = MyTaskOutput(
+                    item_id=parsed_task_details.item_id,
+                    result="Successfully processed item.",
+                    is_complete=True
+                )
+                return AgentOutput(
+                    status="success", 
+                    message=f"Task {task_name} executed by MyNewAgent for item {parsed_task_details.item_id}",
+                    output_data=output_content.dict() # Return Pydantic model as dict
+                )
+            else:
+                return AgentOutput(status="failure", message=f"Unknown task: {task_name}")
+
+        def get_capabilities(self) -> Dict[str, TaskDefinition]:
             return {
-                "name": "MyNewAgent",
-                "description": "Description of what MyNewAgent does.",
-                "tasks": ["my_specific_task_1", "my_specific_task_2"]
+                "my_specific_task_1": TaskDefinition(
+                    task_name="my_specific_task_1",
+                    description="Processes a specific item based on an ID and instruction.",
+                    input_spec=TaskInputSpec(
+                        description="Requires an item ID and a processing instruction.",
+                        schema=MyTaskInput # Reference the Pydantic model for input
+                    ),
+                    output_spec=TaskOutputSpec(
+                        description="Returns the processing result and completion status.",
+                        schema=MyTaskOutput # Reference the Pydantic model for output
+                    )
+                )
+                # Add other tasks here if MyNewAgent can perform more.
             }
     ```
 
-2.  **Implement Agent Logic:**
-    Fill in the logic for `process_request` and/or `execute_task`. Agents can interact with the `ProjectState` to get context or update it with their results (e.g., adding generated file paths, test results).
+3.  **Implement Agent Logic in `execute_task`:**
+    *   Use the `task_name` to switch between different task logics.
+    *   **Crucially, parse and validate `task_details`**. If `task_details` is passed as a dictionary (e.g., from JSON), convert it to your defined Pydantic input model (e.g., `MyTaskInput(**task_details)`). This provides data validation.
+    *   Perform the task.
+    *   Return an `AgentOutput` where the `output_data` field is a dictionary representation of your Pydantic output model (e.g., `my_task_output_instance.dict()`).
 
-3.  **Register the Agent (Conceptual):**
-    *   Add your new agent to `agents/__init__.py` to make it easily importable.
-    *   Add its configuration to `config/agent_config.yaml`. This allows the orchestrator (once fully developed) to discover and use your agent.
+4.  **Register the Agent (Conceptual):**
+    *   Add your new agent to `agents/__init__.py` to make it easily importable:
+        ```python
+        # In agents/__init__.py
+        from .my_new_agent import MyNewAgent
+        # ... other agents
+        ```
+    *   Add its configuration to `config/agent_config.yaml` (if the orchestrator uses it for discovery). This step depends on the orchestrator's design.
+
+## Agent Protocol Benefits
+
+The new agent protocol, centered around `TaskDefinition` and Pydantic model schemas, offers several advantages:
+
+*   **Clear Contracts:** Agents explicitly define their tasks and the expected data structures for inputs and outputs. This makes it easier to understand what an agent does and how to use it.
+*   **Interoperability:** Standardized task definitions and data formats improve how agents can work together. An orchestrator can reliably pass data from one agent's output to another agent's input if their schemas are compatible.
+*   **Discoverability:** The `get_capabilities` method allows an orchestrator (or other tools) to dynamically discover what tasks an agent can perform and the specific data requirements for each task.
+*   **Automatic Validation:** By using Pydantic models for `task_details` (input) and `output_data` (output), data is automatically validated against the defined schemas. This helps catch errors early and ensures data integrity.
+*   **Improved Tooling:** Structured task definitions can be leveraged to automatically generate documentation, user interfaces for interacting with agents, or even client libraries.
+*   **Maintainability:** Clearer interfaces and data structures make the agents easier to maintain and update.
+
+## Orchestrator Interaction with the New Protocol
+
+The new agent protocol significantly enhances how an orchestrator can manage and interact with agents. Here's a conceptual overview:
+
+1.  **Task Discovery & Cataloging:**
+    *   The orchestrator can iterate through all registered/available agents.
+    *   For each agent, it calls `get_capabilities()` to retrieve the dictionary of `TaskDefinition`s.
+    *   This allows the orchestrator to build a comprehensive catalog of all tasks available across the entire agent pool, understanding what each task does, what input it expects (`input_spec.schema`), and what output it produces (`output_spec.schema`).
+
+2.  **Intelligent Task Assignment & Input Validation:**
+    *   When a specific task needs to be performed (e.g., "generate_code_from_plan"), the orchestrator can find an agent that lists this task in its capabilities.
+    *   Before calling `agent.execute_task(task_name="generate_code_from_plan", task_details=some_data, ...)`, the orchestrator can retrieve the `TaskDefinition` for "generate_code_from_plan".
+    *   It can then use the `input_spec.schema` (which is a Pydantic model) from this definition to validate `some_data`. This ensures that `task_details` will conform to the agent's expected input structure, potentially even parsing and transforming `some_data` into the correct Pydantic model instance. This preempts runtime errors within the agent due to mismatched data.
+
+3.  **Structured Output Handling & Validation:**
+    *   Upon receiving an `AgentOutput` from `execute_task`, the orchestrator can again use the `TaskDefinition` for the executed task.
+    *   The `output_spec.schema` (another Pydantic model) from the `TaskDefinition` tells the orchestrator the expected structure of `AgentOutput.output_data`.
+    *   The orchestrator can use this schema to validate the received `output_data`, ensuring it matches the agent's declared output format. This helps in debugging and ensures data consistency.
+
+4.  **Reliable Agent Chaining & Workflow Automation:**
+    *   With explicit input and output schemas for each task, the orchestrator can more reliably chain sequences of agent tasks.
+    *   For example, if `AgentA`'s "task1" has an `output_spec.schema` of `ModelX`, and `AgentB`'s "task2" has an `input_spec.schema` of `ModelX`, the orchestrator can confidently pass the output of `AgentA.task1` as the input to `AgentB.task2`.
+    *   This allows for more dynamic and robust workflow construction, as the orchestrator can programmatically determine compatible tasks and manage the data flow between them. It can even facilitate data transformation if schemas are not directly compatible but can be mapped.
+
+This structured approach moves towards a more predictable and manageable multi-agent system, where the orchestrator acts as an intelligent coordinator, leveraging the self-described capabilities of each agent.
 
 ## Example Agents
 
-*   **`PlannerAgent`:** (Simulated) Takes an `AppSpecification` and creates a high-level plan.
-*   **`CodeGenAgent`:** (Simulated) Generates code based on instructions.
-*   **`TestAgent`:** (Simulated) Runs tests on generated code.
+*   **`PlannerAgent`:** Validates the initial `AppSpecification` and prepares data for code generation. Its `validate_app_specification` task uses `AppSpecification` as input and `ValidatedSpecData` as output.
+*   **`CodeGenAgent`:** Generates or refactors code. Its `generate_code_from_plan` task takes `GenerateCodeInput` (which includes `ValidatedSpecData`) and produces `GeneratedCodeOutput`.
+*   **`TestAgent`:** Generates and runs tests. Its `generate_tests` task takes `GenerateTestsInput` and produces `GeneratedTestsOutput`, while `run_tests` takes `RunTestsInput` and produces `TestRunOutput`.
 
-These examples provide a starting point for developing more sophisticated agents.
+These examples (see their respective files in `agents/`) demonstrate the implementation of the new protocol and provide a practical starting point for developing more sophisticated agents.

--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -1,8 +1,41 @@
 import abc
-from typing import Optional, List, Any, Dict
+from typing import Optional, List, Any, Dict, Type # Added Type
 from pydantic import BaseModel
 from suite_core.app_spec import AppSpecification
 from suite_core.project_state import ProjectState
+
+# --- Task Specification Models ---
+
+class TaskInputSpec(BaseModel):
+    """
+    Describes the expected input schema for an agent's task.
+    The `schema` field itself refers to another Pydantic model
+    that defines the structure of `task_details` for a specific task.
+    """
+    description: str  # Describes the input data
+    schema: Type[BaseModel]  # The Pydantic model defining the structure of task_details
+
+class TaskOutputSpec(BaseModel):
+    """
+    Describes the expected output schema for an agent's task.
+    The `schema` field itself refers to another Pydantic model
+    that defines the structure of `output_data` for a specific task.
+    """
+    description: str  # Describes the output data
+    schema: Type[BaseModel]  # The Pydantic model defining the structure of output_data
+
+class TaskDefinition(BaseModel):
+    """
+    Provides a structured definition for a task that an agent can perform.
+    It includes the task's name, a human-readable description, and
+    specifications for its input and output data structures.
+    """
+    task_name: str
+    description: str
+    input_spec: TaskInputSpec
+    output_spec: TaskOutputSpec
+
+# --- Agent Output Model ---
 
 class AgentOutput(BaseModel):
     status: str
@@ -21,5 +54,5 @@ class BaseAgent(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_capabilities(self) -> dict:
+    def get_capabilities(self) -> Dict[str, TaskDefinition]: # Updated return type hint
         pass

--- a/agents/codegen_agent.py
+++ b/agents/codegen_agent.py
@@ -1,33 +1,129 @@
-from typing import Any
-from .base_agent import BaseAgent, AgentOutput
-from suite_core.app_spec import AppSpecification
+from typing import Any, Dict, List, Union # Added Dict, List, Union
+import logging # Added logging
+
+from pydantic import BaseModel
+from .base_agent import BaseAgent, AgentOutput, TaskDefinition, TaskInputSpec, TaskOutputSpec
+from .planner_agent import ValidatedSpecData # Import from planner_agent
+from suite_core.app_spec import AppSpecification # Keep for process_request type hint
 from suite_core.project_state import ProjectState
+
+logger = logging.getLogger(__name__)
+
+# --- Pydantic Models for Task I/O ---
+
+class GenerateCodeInput(BaseModel):
+    """Input for the 'generate_code_from_plan' task."""
+    plan_data: ValidatedSpecData  # Data from PlannerAgent
+    output_path: str              # Base output path for generated files
+
+class RefactorCodeInput(BaseModel):
+    """Input for the 'refactor_code' task."""
+    files_to_refactor: List[str]
+    refactoring_instructions: str
+
+class GeneratedCodeOutput(BaseModel):
+    """Output for code generation and refactoring tasks."""
+    generated_files: List[str]
 
 class CodeGenAgent(BaseAgent):
     async def process_request(self, app_spec: AppSpecification, project_state: ProjectState) -> AgentOutput:
-        print("CodeGenAgent: Process request called. Typically expects a specific task via execute_task.")
-        return AgentOutput(status="pending", message="Ready for code generation task.")
+        # This method might be deprecated or used for more general, non-task-specific interactions.
+        logger.info("CodeGenAgent: Process request called. Typically expects a specific task via execute_task.")
+        return AgentOutput(status="pending", message="Ready for a specific code generation or refactoring task.")
 
-    async def execute_task(self, task_details: Any, project_state: ProjectState) -> AgentOutput:
-        print(f"CodeGenAgent: Executing task: {task_details}. Simulating code generation for {project_state.app_spec.output_path}.")
-        # Simulate creating a file
-        generated_file_path = f"{project_state.app_spec.output_path}/generated_code.py"
-        
-        # Ensure generated_files list exists and append
-        if not hasattr(project_state, 'generated_files') or project_state.generated_files is None:
-            project_state.generated_files = []
-        project_state.generated_files.append(generated_file_path)
-        
-        return AgentOutput(
-            status="success",
-            message=f"Code generation simulated. Output in {generated_file_path}.",
-            output_data={"generated_files": [generated_file_path]},
-            next_agent_hint="TestAgent"
-        )
+    async def execute_task(self, task_name: str, task_details: Union[GenerateCodeInput, RefactorCodeInput, Dict[str, Any]], project_state: ProjectState) -> AgentOutput:
+        logger.info(f"CodeGenAgent: Executing task '{task_name}' with details: {task_details}")
 
-    def get_capabilities(self) -> dict:
+        parsed_task_details: Union[GenerateCodeInput, RefactorCodeInput, None] = None
+
+        if task_name == "generate_code_from_plan":
+            if isinstance(task_details, GenerateCodeInput):
+                parsed_task_details = task_details
+            elif isinstance(task_details, dict):
+                try:
+                    parsed_task_details = GenerateCodeInput(**task_details)
+                except Exception as e:
+                    logger.error(f"Error parsing task_details for generate_code_from_plan: {e}")
+                    return AgentOutput(status="failure", message=f"Invalid task_details for generate_code_from_plan: {e}")
+            else:
+                return AgentOutput(status="failure", message="Invalid task_details type for generate_code_from_plan.")
+            
+            # Simulate creating a file using output_path from parsed_task_details
+            # For the simulation, we'll use the project_state's app_spec output_path if task_details.output_path is not directly usable
+            # or if we want to ensure it's rooted correctly. In a real scenario, task_details.output_path would be primary.
+            output_dir = parsed_task_details.output_path # This should be the apps/my_generated_app
+            generated_file_path = f"{output_dir}/generated_code_from_plan.py" # Example file
+            logger.info(f"Simulating code generation for: {output_dir}. Output file: {generated_file_path}")
+
+            # Ensure generated_files list exists and append
+            if project_state.generated_files is None: # Check if None, not hasattr
+                project_state.generated_files = []
+            project_state.generated_files.append(generated_file_path)
+            
+            output_data = GeneratedCodeOutput(generated_files=[generated_file_path])
+            return AgentOutput(
+                status="success",
+                message=f"Code generation simulated. Output in {generated_file_path}.",
+                output_data=output_data.dict(), # Ensure Pydantic model is dict for AgentOutput
+                next_agent_hint="TestAgent"
+            )
+
+        elif task_name == "refactor_code":
+            if isinstance(task_details, RefactorCodeInput):
+                parsed_task_details = task_details
+            elif isinstance(task_details, dict):
+                try:
+                    parsed_task_details = RefactorCodeInput(**task_details)
+                except Exception as e:
+                    logger.error(f"Error parsing task_details for refactor_code: {e}")
+                    return AgentOutput(status="failure", message=f"Invalid task_details for refactor_code: {e}")
+            else:
+                return AgentOutput(status="failure", message="Invalid task_details type for refactor_code.")
+
+            logger.info(f"Simulating refactoring for files: {parsed_task_details.files_to_refactor} with instructions: '{parsed_task_details.refactoring_instructions}'")
+            # Simulate modifying files - for now, just list them as "modified"
+            modified_files = [f"refactored_{os.path.basename(f)}" for f in parsed_task_details.files_to_refactor] # Simulate new names
+            
+            if project_state.generated_files is None:
+                project_state.generated_files = []
+            project_state.generated_files.extend(modified_files) # Add all "refactored" files
+            
+            output_data = GeneratedCodeOutput(generated_files=modified_files)
+            return AgentOutput(
+                status="success",
+                message=f"Refactoring simulated. Modified files: {', '.join(modified_files)}.",
+                output_data=output_data.dict(),
+                next_agent_hint="TestAgent" # Or perhaps back to Planner or a ReviewAgent
+            )
+        else:
+            logger.warning(f"CodeGenAgent: Unknown task_name '{task_name}'")
+            return AgentOutput(status="failure", message=f"Unknown task_name: {task_name}")
+
+    def get_capabilities(self) -> Dict[str, TaskDefinition]:
         return {
-            "name": "CodeGenAgent",
-            "description": "Generates code based on specifications or plans.",
-            "tasks": ["generate_code_from_plan", "refactor_code"]
+            "generate_code_from_plan": TaskDefinition(
+                task_name="generate_code_from_plan",
+                description="Generates code based on planning data (e.g., validated specification, template details).",
+                input_spec=TaskInputSpec(
+                    description="Plan details (ValidatedSpecData from PlannerAgent) and the target output path for code generation.",
+                    schema=GenerateCodeInput
+                ),
+                output_spec=TaskOutputSpec(
+                    description="List of paths to the generated code files.",
+                    schema=GeneratedCodeOutput
+                )
+            ),
+            "refactor_code": TaskDefinition(
+                task_name="refactor_code",
+                description="Refactors existing code files based on specific instructions.",
+                input_spec=TaskInputSpec(
+                    description="A list of file paths to refactor and natural language instructions for the refactoring process.",
+                    schema=RefactorCodeInput
+                ),
+                output_spec=TaskOutputSpec(
+                    description="List of paths to the modified or newly generated files resulting from refactoring.",
+                    schema=GeneratedCodeOutput
+                )
+            )
         }
+import os # Added os for basename in refactor_code simulation

--- a/agents/test_agent.py
+++ b/agents/test_agent.py
@@ -1,30 +1,140 @@
-from typing import Any
-from .base_agent import BaseAgent, AgentOutput
-from suite_core.app_spec import AppSpecification
+from typing import Any, Dict, List, Optional, Union # Added Dict, List, Optional, Union
+import logging # Added logging
+import os # Added os for path manipulation in simulation
+
+from pydantic import BaseModel
+from .base_agent import BaseAgent, AgentOutput, TaskDefinition, TaskInputSpec, TaskOutputSpec
+from suite_core.app_spec import AppSpecification # Keep for process_request type hint
 from suite_core.project_state import ProjectState
+
+logger = logging.getLogger(__name__)
+
+# --- Pydantic Models for Task I/O ---
+
+class GenerateTestsInput(BaseModel):
+    """Input for the 'generate_tests' task."""
+    files_to_test: List[str]
+    test_strategy: Optional[str] = None
+
+class GeneratedTestsOutput(BaseModel):
+    """Output for the 'generate_tests' task."""
+    generated_test_files: List[str]
+
+class RunTestsInput(BaseModel):
+    """Input for the 'run_tests' task."""
+    test_files: List[str]
+    code_files_under_test: List[str] # Added as per instruction
+
+class TestRunOutput(BaseModel):
+    """Output for the 'run_tests' task."""
+    test_summary: Dict[str, Any] # e.g., {"passed": 5, "failed": 0, "coverage": "70%"}
 
 class TestAgent(BaseAgent):
     async def process_request(self, app_spec: AppSpecification, project_state: ProjectState) -> AgentOutput:
-        print("TestAgent: Process request called. Typically expects a specific task via execute_task.")
-        return AgentOutput(status="pending", message="Ready for testing task.")
+        # This method might be deprecated or used for more general, non-task-specific interactions.
+        logger.info("TestAgent: Process request called. Typically expects a specific task via execute_task.")
+        return AgentOutput(status="pending", message="Ready for a specific testing task.")
 
-    async def execute_task(self, task_details: Any, project_state: ProjectState) -> AgentOutput:
-        print(f"TestAgent: Executing task: {task_details}. Simulating running tests for {project_state.app_spec.output_path}.")
-        # Simulate test results
-        test_results = {"passed": 5, "failed": 0, "coverage": "70%"}
-        
-        project_state.test_results = test_results
-        
-        return AgentOutput(
-            status="success",
-            message="Tests simulated. All passed.",
-            output_data={"test_summary": test_results},
-            next_agent_hint="DeployAgent" # DeployAgent not created in this step
-        )
+    async def execute_task(self, task_name: str, task_details: Union[GenerateTestsInput, RunTestsInput, Dict[str, Any]], project_state: ProjectState) -> AgentOutput:
+        logger.info(f"TestAgent: Executing task '{task_name}' with details: {task_details}")
 
-    def get_capabilities(self) -> dict:
+        parsed_task_details: Union[GenerateTestsInput, RunTestsInput, None] = None
+
+        if task_name == "generate_tests":
+            if isinstance(task_details, GenerateTestsInput):
+                parsed_task_details = task_details
+            elif isinstance(task_details, dict):
+                try:
+                    parsed_task_details = GenerateTestsInput(**task_details)
+                except Exception as e:
+                    logger.error(f"Error parsing task_details for generate_tests: {e}")
+                    return AgentOutput(status="failure", message=f"Invalid task_details for generate_tests: {e}")
+            else:
+                return AgentOutput(status="failure", message="Invalid task_details type for generate_tests.")
+
+            logger.info(f"Simulating test generation for files: {parsed_task_details.files_to_test} with strategy: {parsed_task_details.test_strategy or 'default'}")
+            
+            generated_test_files = []
+            for file_to_test in parsed_task_details.files_to_test:
+                # Simulate creating a test file based on the original file name
+                base, ext = os.path.splitext(file_to_test)
+                # Assuming files might be in a directory like 'app/src/module.py'
+                # We want to place tests in a similar structure, e.g., 'app/tests/test_module.py'
+                # This is a simplified simulation for path handling.
+                file_name = os.path.basename(base)
+                # Try to place it in a 'tests' subdirectory relative to the app's output path.
+                # project_state.app_spec.output_path could be like 'apps/my_generated_app'
+                test_file_path = os.path.join(project_state.app_spec.output_path, "tests", f"test_{file_name}{ext if ext else '.py'}")
+                generated_test_files.append(test_file_path)
+            
+            logger.info(f"Simulated generated test files: {generated_test_files}")
+            
+            # Update project_state if needed (e.g., if it tracks all generated files)
+            if project_state.generated_files is None:
+                project_state.generated_files = []
+            project_state.generated_files.extend(generated_test_files) # Add new test files
+
+            output_data = GeneratedTestsOutput(generated_test_files=generated_test_files)
+            return AgentOutput(
+                status="success",
+                message=f"Test generation simulated. Generated files: {', '.join(generated_test_files)}",
+                output_data=output_data.dict(),
+                next_agent_hint="TestAgent" # Or CodeGenAgent if tests need to be written to disk by it
+            )
+
+        elif task_name == "run_tests":
+            if isinstance(task_details, RunTestsInput):
+                parsed_task_details = task_details
+            elif isinstance(task_details, dict):
+                try:
+                    parsed_task_details = RunTestsInput(**task_details)
+                except Exception as e:
+                    logger.error(f"Error parsing task_details for run_tests: {e}")
+                    return AgentOutput(status="failure", message=f"Invalid task_details for run_tests: {e}")
+            else:
+                return AgentOutput(status="failure", message="Invalid task_details type for run_tests.")
+
+            logger.info(f"Simulating running tests for files: {parsed_task_details.test_files} against code: {parsed_task_details.code_files_under_test}")
+            # Simulate test results
+            simulated_test_results = {"passed": len(parsed_task_details.test_files) * 2, "failed": 0, "coverage": "85%"}
+            
+            project_state.test_results = simulated_test_results # Update project_state
+            
+            output_data = TestRunOutput(test_summary=simulated_test_results)
+            return AgentOutput(
+                status="success",
+                message="Tests simulated. All passed (simulated).",
+                output_data=output_data.dict(),
+                next_agent_hint=None # Or DeployAgent if tests pass
+            )
+        else:
+            logger.warning(f"TestAgent: Unknown task_name '{task_name}'")
+            return AgentOutput(status="failure", message=f"Unknown task_name: {task_name}")
+
+    def get_capabilities(self) -> Dict[str, TaskDefinition]:
         return {
-            "name": "TestAgent",
-            "description": "Generates and runs tests for code.",
-            "tasks": ["generate_tests", "run_tests"]
+            "generate_tests": TaskDefinition(
+                task_name="generate_tests",
+                description="Generates test files for specified source code files.",
+                input_spec=TaskInputSpec(
+                    description="Files to generate tests for and an optional testing strategy.",
+                    schema=GenerateTestsInput
+                ),
+                output_spec=TaskOutputSpec(
+                    description="List of paths to the generated test files.",
+                    schema=GeneratedTestsOutput
+                )
+            ),
+            "run_tests": TaskDefinition(
+                task_name="run_tests",
+                description="Runs specified test files against corresponding code files and reports results.",
+                input_spec=TaskInputSpec(
+                    description="Test files and the code files they are intended to test.",
+                    schema=RunTestsInput
+                ),
+                output_spec=TaskOutputSpec(
+                    description="A summary of the test execution results, including pass/fail counts and coverage.",
+                    schema=TestRunOutput
+                )
+            )
         }


### PR DESCRIPTION
…ts, and outputs in a structured, machine-readable way.

Key changes:
- Added Pydantic models (`TaskDefinition`, `TaskInputSpec`, `TaskOutputSpec`) to `agents/base_agent.py` for agents to declare their tasks and associated data schemas.
- Modified `BaseAgent.get_capabilities` to return `Dict[str, TaskDefinition]`, providing explicit contracts for each agent task.
- Updated `PlannerAgent`, `CodeGenAgent`, and `TestAgent` to conform to this new protocol:
    - Defined specific Pydantic models for their task inputs and outputs.
    - Implemented the new `get_capabilities` format.
    - Adapted `execute_task` to handle named tasks and validate inputs against their schemas.
- Updated `agents/README.md` extensively to document the new protocol, its benefits, and provide examples for developers. This includes a conceptual overview of how an orchestrator could use this protocol.